### PR TITLE
Add basic chat router with model selection and tool support.

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from app.router import chat_router
+
+app = FastAPI(title="LLM-Agnostic Chatbot")
+
+# Your API
+app.include_router(chat_router, prefix="/chat")

--- a/app/router.py
+++ b/app/router.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from app.llms.openai_llm import OpenAIClient
+from app.llms.groq_llm import GroqClient
+from app.tools.bank_tools import TOOL_FUNCTIONS
+
+router = APIRouter()
+
+class ChatRequest(BaseModel):
+    message: str
+    session_id: str
+    model: str  # e.g. "gpt-4" or "llama3"
+
+@router.post("/")
+async def chat(req: ChatRequest):
+    if req.model == "gpt-4":
+        client = OpenAIClient()
+    elif req.model == "llama3":
+        client = GroqClient()
+    else:
+        return {"error": "Unsupported model"}
+
+    return await client.chat(req.message, req.session_id, TOOL_FUNCTIONS)
+
+# ✅ This line is required for the import to work
+chat_router = router


### PR DESCRIPTION
**📄 Description:**

This PR adds the initial chat routing logic that receives user input and dispatches it to the appropriate LLM client (OpenAIClient or GroqClient).

**✨ Changes:**
Added app/router.py with a /chat POST endpoint.

Defined ChatRequest model (message, session_id, model).

Routes to gpt-4 (OpenAI) or llama3 (Groq) based on the request.

Passes tool functions via TOOL_FUNCTIONS.

**✅ Why:**
This sets up the primary entry point for chat requests and lays the foundation for LLM-based interaction in future features.