### PR TITLE
chore: configure CORS to allow requests from frontend origins

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,5 +4,19 @@ from app.router import chat_router
 
 app = FastAPI(title="LLM-Agnostic Chatbot")
 
+origins = [
+    "http://localhost:5173",
+    "https://chatbot-frontend-nkqapod1t-amrmaghrabys-projects.vercel.app",
+    "https://chatbot-frontend-git-main-amrmaghrabys-projects.vercel.app",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 # Your API
 app.include_router(chat_router, prefix="/chat")


### PR DESCRIPTION
**📄 Description:**

This PR adds CORS (Cross-Origin Resource Sharing) configuration to allow the frontend application (both local and deployed environments) to access backend APIs without CORS errors.

**✨ Changes:**
Added the allowed list of origins:

Applied CORSMiddleware to the FastAPI app with:

allow_credentials=True

allow_methods=["*"]

allow_headers=["*"]

**✅ Why:**
To ensure that requests from the frontend to the backend (e.g. for /chat) are allowed during development and production.